### PR TITLE
ci: Add tests for supported Go versions

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -29,11 +29,19 @@ jobs:
   # Unit tests for Go code
   ######################################
 
-  unit-tests:
+  unit-tests-matrix:
     name: unit tests
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version:
+          - "1.20"
+          - "1.19"
+          - "1.18"
+          - "1.17"
+          - "1.16"
+          - "1.15"
+          - "1.14"
+          - "1.13"
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     if: ${{ always() }}
@@ -51,6 +59,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           fail_ci_if_error: true
+
+  # NOTE: needed for protected branch checks.
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: [unit-tests-matrix]
+    if: ${{ always() }}
+    env:
+      UNIT_TESTS_RESULT: ${{ needs.unit-tests-matrix.result }}
+    steps:
+      - run: |
+          [ "${UNIT_TESTS_RESULT}" == "success" ]
 
   # autogen for license headers
   ###############################

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ianlewis/runeio
 
-go 1.20
+go 1.13

--- a/reader_test.go
+++ b/reader_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // sliceEqual returns true if the two slices are equal.
-func sliceEqual[T comparable](l, r []T) bool {
+func sliceEqual(l, r []rune) bool {
 	if len(l) != len(r) {
 		return false
 	}


### PR DESCRIPTION
Add supported Go versions (1.13~) to the test matrix on pre-submits.

Fixes #13