### PR TITLE
ci: Add cocogitto check

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -71,6 +71,19 @@ jobs:
       - run: |
           [ "${UNIT_TESTS_RESULT}" == "success" ]
 
+  cog-check:
+    runs-on: ubuntu-latest
+    name: check conventional commit compliance
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          fetch-depth: 0
+          # pick the pr HEAD instead of the merge commit
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Conventional commit check
+        uses: cocogitto/cocogitto-action@ac6260150ee57e3164cd95b47fc84cdee9e3444c # v3.5
+
   # autogen for license headers
   ###############################
 

--- a/cog.toml
+++ b/cog.toml
@@ -5,12 +5,14 @@
 
 pre_bump_hooks = [
     "echo {{version}}",
+    "git checkout -b release-{{version}}"
 ]
 
 
 post_bump_hooks = [
-    "git push",
-    "git push origin {{version}}",
+    # Delete the version because we have to create a PR first.
+    "git tag -d {{version}}",
+    "gh pr create --title \"$(git log -1 --pretty=%B | head -n1)\""
 ]
 
 [changelog]


### PR DESCRIPTION
Adds a cocogitto-action check as a pre-submit workflow to make sure commits are conventional commits.

Fixes #24