### PR TITLE
chore: Remove exteraneous err check

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -154,16 +154,11 @@ func (r *RuneReader) Peek(n int) ([]rune, error) {
 		r.fill(n)
 	}
 
-	var err error
 	if n > r.buffered() {
 		n = r.buffered()
-		err = r.readErr()
-		if err == nil {
-			err = ErrBufferFull
-		}
 	}
 
-	return r.buf[r.r : r.r+n], err
+	return r.buf[r.r : r.r+n], r.readErr()
 }
 
 // Reset discards any buffered data, resets all state, and switches the


### PR DESCRIPTION
Remove an error check in `Peek` who's condition could never happen. The only way the number of buffered runes would be smaller than the number requested is if an error was set.