### PR TITLE
docs: Update conventional commit types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,8 +220,7 @@ number MAJOR.MINOR.PATCH, increment the:
 ### Conventional Commits
 
 PR titles are required to be in [Conventional Commits] format. Supported
-prefixes are defined in the file
-[`.github/pr-title-checker-config.json`](./.github/pr-title-checker-config.json).
+prefixes are defined in the file [`cog.toml`](./cog.toml).
 
 The following prefixes are supported:
 

--- a/cog.toml
+++ b/cog.toml
@@ -11,12 +11,23 @@ pre_bump_hooks = [
     "git checkout -b release-{{version}}"
 ]
 
-
 post_bump_hooks = [
     # Delete the version because we have to create a PR first.
-    "git tag -d {{version}}",
-    "gh pr create --title \"$(git log -1 --pretty=%B | head -n1)\""
+    "git tag -d {{version}}"
 ]
+
+[commit_types]
+feat = { changelog_title = "Features" }
+fix = { changelog_title = "Bug Fixes" }
+docs = { changelog_title = "", omit_from_changelog = true }
+chore = { changelog_title = "", omit_from_changelog = true }
+refactor = { changelog_title = "", omit_from_changelog = true }
+style = { changelog_title = "", omit_from_changelog = true }
+build = { changelog_title = "", omit_from_changelog = true }
+ci = { changelog_title = "", omit_from_changelog = true }
+perf = { changelog_title = "Performance Improvements" }
+revert = { changelog_title = "", omit_from_changelog = true }
+test = { changelog_title = "", omit_from_changelog = true }
 
 [changelog]
 path = "CHANGELOG.md"


### PR DESCRIPTION
Add config for conventional commit types to `cog.toml` and update contributor docs accordingly.