### PR TITLE
feat: Add `Buffered` method.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -95,7 +95,7 @@ func (r *RuneReader) Read(p []rune) (int, error) {
 func (r *RuneReader) ReadRune() (rune, int, error) {
 	r.fill(1)
 
-	if r.buffered() == 0 {
+	if r.Buffered() == 0 {
 		return 0, 0, r.readErr()
 	}
 
@@ -146,12 +146,12 @@ func (r *RuneReader) Peek(n int) ([]rune, error) {
 
 	r.lastRune = -1
 
-	if n > r.buffered() {
+	if n > r.Buffered() {
 		r.fill(n)
 	}
 
-	if n > r.buffered() {
-		n = r.buffered()
+	if n > r.Buffered() {
+		n = r.Buffered()
 	}
 
 	return r.buf[r.r : r.r+n], r.readErr()
@@ -199,8 +199,8 @@ func (r *RuneReader) UnreadRune() error {
 	return nil
 }
 
-// buffered returns the number of runes that can be read from the buffer.
-func (r *RuneReader) buffered() int {
+// Buffered returns the number of runes that can be read from the buffer.
+func (r *RuneReader) Buffered() int {
 	return r.e - r.r
 }
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -814,6 +814,60 @@ func BenchmarkReadLarge(b *testing.B) {
 	}
 }
 
+func BenchmarkNoCopySmall(b *testing.B) {
+	n := 512
+	s := strings.Repeat("x", n+1)
+	rs := strings.NewReader(s)
+	rr := NewReader(rs)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var read int
+		for read < n {
+			n := rr.Buffered()
+			if n == 0 {
+				n = 1
+			}
+			//nolint:errcheck // errors not checked in benchmarks.
+			buf, _ := rr.Peek(n)
+			p := len(buf)
+			//nolint:errcheck // errors not checked in benchmarks.
+			_, _ = rr.Discard(p)
+			read += p
+		}
+
+		rs.Reset(s)
+		rr.Reset(rs)
+	}
+}
+
+func BenchmarkNoCopyLarge(b *testing.B) {
+	n := 32 * 1024
+	s := strings.Repeat("x", n+1)
+	rs := strings.NewReader(s)
+	rr := NewReader(rs)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var read int
+		for read < n {
+			n := rr.Buffered()
+			if n == 0 {
+				n = 1
+			}
+			//nolint:errcheck // errors not checked in benchmarks.
+			buf, _ := rr.Peek(n)
+			p := len(buf)
+			//nolint:errcheck // errors not checked in benchmarks.
+			_, _ = rr.Discard(p)
+			read += p
+		}
+
+		rs.Reset(s)
+		rr.Reset(rs)
+	}
+}
+
 func BenchmarkPeekSmall(b *testing.B) {
 	n := 512
 	s := strings.Repeat("x", n+1)


### PR DESCRIPTION
Adds a `Buffered` method that returns the number of currently buffered runes. Also adds a "NoCopy" benchmark that benchmarks reading a full stream using the no-copy method w/ Peek and Discard.

Fixes: #51