### PR TITLE
perf: Fill buffer to minimize copies

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -775,7 +775,7 @@ func BenchmarkReadRune(b *testing.B) {
 	s := strings.Repeat("x", n)
 	rs := strings.NewReader(s)
 	rr := NewReaderSize(rs, n)
-	rr.fill(n)
+	rr.fill()
 	b.ResetTimer()
 
 	var total int
@@ -789,7 +789,7 @@ func BenchmarkReadRune(b *testing.B) {
 			b.StopTimer()
 			rs.Reset(s)
 			rr.Reset(rs)
-			rr.fill(rr.Size())
+			rr.fill()
 			total = 0
 			b.StartTimer()
 		}
@@ -824,7 +824,7 @@ func BenchmarkReadSmall(b *testing.B) {
 	s := strings.Repeat("x", n)
 	rs := strings.NewReader(s)
 	rr := NewReaderSize(rs, n)
-	rr.fill(n)
+	rr.fill()
 	buf := make([]rune, readsize)
 	b.ResetTimer()
 
@@ -839,7 +839,7 @@ func BenchmarkReadSmall(b *testing.B) {
 			b.StopTimer()
 			rs.Reset(s)
 			rr.Reset(rs)
-			rr.fill(n)
+			rr.fill()
 			total = 0
 			b.StartTimer()
 		}
@@ -851,7 +851,7 @@ func BenchmarkReadLarge(b *testing.B) {
 	s := strings.Repeat("x", n)
 	rs := strings.NewReader(s)
 	rr := NewReaderSize(rs, n)
-	rr.fill(n)
+	rr.fill()
 	buf := make([]rune, n)
 	b.ResetTimer()
 
@@ -864,7 +864,7 @@ func BenchmarkReadLarge(b *testing.B) {
 		b.StopTimer()
 		rs.Reset(s)
 		rr.Reset(rs)
-		rr.fill(n)
+		rr.fill()
 		b.StartTimer()
 	}
 }
@@ -941,7 +941,7 @@ func BenchmarkPeekSmall(b *testing.B) {
 	s := strings.Repeat("x", 512)
 	rs := strings.NewReader(s)
 	rr := NewReaderSize(rs, rs.Len())
-	rr.fill(rr.Size())
+	rr.fill()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -956,7 +956,7 @@ func BenchmarkPeekLarge(b *testing.B) {
 	s := strings.Repeat("x", 32*1024)
 	rs := strings.NewReader(s)
 	rr := NewReaderSize(rs, rs.Len())
-	rr.fill(rr.Size())
+	rr.fill()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -973,7 +973,7 @@ func BenchmarkDiscardSmall(b *testing.B) {
 	s := strings.Repeat("x", n)
 	rs := strings.NewReader(s)
 	rr := NewReaderSize(rs, n)
-	rr.fill(n)
+	rr.fill()
 	b.ResetTimer()
 
 	var total int
@@ -987,7 +987,7 @@ func BenchmarkDiscardSmall(b *testing.B) {
 			b.StopTimer()
 			rs.Reset(s)
 			rr.Reset(rs)
-			rr.fill(rr.Size())
+			rr.fill()
 			total = 0
 			b.StartTimer()
 		}
@@ -999,7 +999,7 @@ func BenchmarkDiscardLarge(b *testing.B) {
 	s := strings.Repeat("x", n)
 	rs := strings.NewReader(s)
 	rr := NewReaderSize(rs, n)
-	rr.fill(n)
+	rr.fill()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -1011,7 +1011,7 @@ func BenchmarkDiscardLarge(b *testing.B) {
 		b.StopTimer()
 		rs.Reset(s)
 		rr.Reset(rs)
-		rr.fill(n)
+		rr.fill()
 		b.StartTimer()
 	}
 }
@@ -1028,7 +1028,7 @@ func BenchmarkFill(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		rr.fill(n)
+		rr.fill()
 		if rr.err != nil {
 			b.Fatal(rr.err)
 		}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/ianlewis/runeio
cpu: Intel(R) Core(TM) i7-7567U CPU @ 3.50GHz
                     │   old.txt    │               new.txt                │
                     │    sec/op    │    sec/op     vs base                │
ReadRune-4             6.238n ± 10%   4.649n ±  9%  -25.47% (p=0.000 n=15)
ReadRuneUnbuffered-4   9.886n ±  7%   6.758n ±  7%  -31.64% (p=0.000 n=15)
ReadSmall-4            3.015µ ± 10%   1.988µ ± 12%  -34.06% (p=0.000 n=15)
ReadLarge-4            201.3µ ± 15%   123.8µ ± 11%  -38.51% (p=0.000 n=15)
NoCopySmall-4          250.4µ ±  1%   206.3µ ±  7%  -17.61% (p=0.000 n=15)
NoCopyLarge-4          7.780m ±  1%   6.648m ±  7%  -14.55% (p=0.000 n=15)
PeekSmall-4            3.527n ±  6%   3.275n ±  4%   -7.14% (p=0.000 n=15)
PeekLarge-4            3.526n ±  0%   3.276n ±  6%   -7.09% (p=0.000 n=15)
DiscardSmall-4         2.492µ ± 13%   1.759µ ±  7%  -29.41% (p=0.000 n=15)
DiscardLarge-4         181.8µ ±  8%   114.2µ ± 16%  -37.17% (p=0.000 n=15)
Fill-4                 36.42µ ±  6%   36.89µ ±  7%   +1.30% (p=0.016 n=15)
geomean                2.396µ         1.845µ        -23.01%
```

Fixes #52 